### PR TITLE
fix: add namespace to adapter.dispatch(), qualify macro calls

### DIFF
--- a/macros/columns/base/date.sql
+++ b/macros/columns/base/date.sql
@@ -1,6 +1,6 @@
 {% macro synth_column_date(name, min='1990-01-01', max='', distribution='uniform') -%}
     {% set base_field %}
-        {{ adapter.dispatch('synth_column_date_base')(min, max, distribution) }} AS {{name}}
+        {{ adapter.dispatch('synth_column_date_base', 'dbt_synth_data')(min, max, distribution) }} AS {{name}}
     {% endset %}
     {{ synth_store('base_fields', name, base_field) }}
 

--- a/macros/columns/base/date_sequence.sql
+++ b/macros/columns/base/date_sequence.sql
@@ -1,6 +1,6 @@
 {% macro synth_column_date_sequence(name, start_date='', step=1) -%}
     {% set base_field %}
-        {{ adapter.dispatch('synth_column_date_sequence_base')(start_date, step) }} AS {{name}}
+        {{ adapter.dispatch('synth_column_date_sequence_base', 'dbt_synth_data')(start_date, step) }} AS {{name}}
     {% endset %}
     {{ dbt_synth_data.synth_store('base_fields', name, base_field) }}
 

--- a/macros/columns/base/geopoint.sql
+++ b/macros/columns/base/geopoint.sql
@@ -1,6 +1,6 @@
 {% macro synth_column_geopoint(name) -%}
     {% set base_field %}
-        {{ adapter.dispatch('synth_column_geopoint_base')() }} AS {{name}}
+        {{ adapter.dispatch('synth_column_geopoint_base', 'dbt_synth_data')() }} AS {{name}}
     {% endset %}
     {{ dbt_synth_data.synth_store('base_fields', name, base_field) }}
 

--- a/macros/columns/base/primary_key.sql
+++ b/macros/columns/base/primary_key.sql
@@ -1,6 +1,6 @@
 {% macro synth_column_primary_key(name) -%}
     {% set base_field %}
-        {{ adapter.dispatch('synth_column_primary_key')() }} as {{name}}
+        {{ adapter.dispatch('synth_column_primary_key', 'dbt_synth_data')() }} as {{name}}
     {% endset %}
     {{ dbt_synth_data.synth_store('base_fields', name, base_field) }}
 

--- a/macros/columns/base/string.sql
+++ b/macros/columns/base/string.sql
@@ -1,5 +1,5 @@
 {% macro synth_column_string(name, min_length=1, max_length=32) -%}
-    {{ return(adapter.dispatch('synth_column_string_base')(name, min_length, max_length)) }}
+    {{ return(adapter.dispatch('synth_column_string_base', 'dbt_synth_data')(name, min_length, max_length)) }}
 {%- endmacro %}
 
 {% macro default__synth_column_string_base(name, min_length, max_length) -%}

--- a/macros/columns/composite/phone_number.sql
+++ b/macros/columns/composite/phone_number.sql
@@ -1,11 +1,11 @@
 {% macro synth_column_phone_number(name) -%}
     {% set join_fields %}
         '(' ||
-        {{ adapter.dispatch('synth_column_phone_number_chunk')(min=100, max=1000, pad_length=3) }}
+        {{ adapter.dispatch('synth_column_phone_number_chunk', 'dbt_synth_data')(min=100, max=1000, pad_length=3) }}
         || ') ' ||
-        {{ adapter.dispatch('synth_column_phone_number_chunk')(min=100, max=1000, pad_length=3) }}
+        {{ adapter.dispatch('synth_column_phone_number_chunk', 'dbt_synth_data')(min=100, max=1000, pad_length=3) }}
         || '-' ||
-        {{ adapter.dispatch('synth_column_phone_number_chunk')(min=1, max=1000, pad_length=4) }}
+        {{ adapter.dispatch('synth_column_phone_number_chunk', 'dbt_synth_data')(min=1, max=1000, pad_length=4) }}
         as {{name}}
     {% endset %}
     {{ dbt_synth_data.synth_store("joins", name+"__cte", {"fields": join_fields, "clause": ""} ) }}

--- a/macros/distributions/continuous/normal.sql
+++ b/macros/distributions/continuous/normal.sql
@@ -1,5 +1,5 @@
 {% macro synth_distribution_continuous_normal(mean=0, stddev=1) -%}
-    {{ return(adapter.dispatch('synth_distribution_continuous_normal')(mean, stddev)) }}
+    {{ return(adapter.dispatch('synth_distribution_continuous_normal', 'dbt_synth_data')(mean, stddev)) }}
 {%- endmacro %}
 
 {% macro default__synth_distribution_continuous_normal(mean, stddev) -%}

--- a/macros/distributions/continuous/uniform.sql
+++ b/macros/distributions/continuous/uniform.sql
@@ -1,5 +1,5 @@
 {% macro synth_distribution_continuous_uniform(min=0, max=1) -%}
-    {{ return(adapter.dispatch('synth_distribution_continuous_uniform')(min, max)) }}
+    {{ return(adapter.dispatch('synth_distribution_continuous_uniform', 'dbt_synth_data')(min, max)) }}
 {%- endmacro %}
 
 {% macro default__synth_distribution_continuous_uniform(min, max) -%}

--- a/macros/distributions/discretize.sql
+++ b/macros/distributions/discretize.sql
@@ -1,5 +1,5 @@
 {% macro synth_distribution_discretize_floor(distribution) %}
-    {{ return(adapter.dispatch('synth_distribution_discretize_floor')(distribution)) }}
+    {{ return(adapter.dispatch('synth_distribution_discretize_floor', 'dbt_synth_data')(distribution)) }}
 {% endmacro %}
 
 {% macro default__synth_distribution_discretize_floor(distribution) -%}
@@ -25,7 +25,7 @@
 
 
 {% macro synth_distribution_discretize_ceil(distribution) %}
-    {{ return(adapter.dispatch('synth_distribution_discretize_ceil')(distribution)) }}
+    {{ return(adapter.dispatch('synth_distribution_discretize_ceil', 'dbt_synth_data')(distribution)) }}
 {% endmacro %}
 
 {% macro default__synth_distribution_discretize_ceil(distribution) -%}
@@ -51,7 +51,7 @@
 
 
 {% macro synth_distribution_discretize_round(distribution, precision=0) %}
-    {{ return(adapter.dispatch('synth_distribution_discretize_round')(distribution, precision)) }}
+    {{ return(adapter.dispatch('synth_distribution_discretize_round', 'dbt_synth_data')(distribution, precision)) }}
 {% endmacro %}
 
 {% macro default__synth_distribution_discretize_round(distribution, precision) -%}

--- a/macros/synth_var.sql
+++ b/macros/synth_var.sql
@@ -1,5 +1,5 @@
 {% macro synth_var(data) %}
-    {{ return(synth_dynamic_var(var(data))) }}
+    {{ return(dbt_synth_data.synth_dynamic_var(var(data))) }}
 {% endmacro %}
 
 {% macro synth_dynamic_var(data) %}
@@ -35,13 +35,13 @@
         {% set my_macro = first_key[0:-2] %}
         {% set my_params = {} %}
         {% for param, value in data[first_key]|items %}
-            {% do my_params.update({param: synth_dynamic_var(value)}) %}
+            {% do my_params.update({param: dbt_synth_data.synth_dynamic_var(value)}) %}
         {% endfor %}
-        {{ return(synth_call_macro(my_macro, my_params)) }}
+        {{ return(dbt_synth_data.synth_call_macro(my_macro, my_params)) }}
     {% elif data is string and data[-2:]=="()" %}
         {# CASE B #}
         {% set my_macro = data[0:-2] %}
-        {{ synth_call_macro(my_macro, {})() }}
+        {{ dbt_synth_data.synth_call_macro(my_macro, {})() }}
     {% else %}
         {# CASE C #}
         {{ return(data) }}

--- a/macros/table.sql
+++ b/macros/table.sql
@@ -1,5 +1,5 @@
 {% macro synth_table(rows=1000) -%}
-    {{ return(adapter.dispatch('synth_table')(rows)) }}
+    {{ return(adapter.dispatch('synth_table', 'dbt_synth_data')(rows)) }}
 {% endmacro %}
 
 {% macro default__synth_table(rows=1000) -%}
@@ -17,8 +17,8 @@
     
     {{table_name}}__base as (
         select
-            {{ adapter.dispatch('synth_table_rownum')() }} as __row_number
-        from {{ adapter.dispatch('synth_table_generator')(rows) }}
+            {{ adapter.dispatch('synth_table_rownum', 'dbt_synth_data')() }} as __row_number
+        from {{ adapter.dispatch('synth_table_generator', 'dbt_synth_data')(rows) }}
     ),
     {{table_name}}__join0 as (
         select
@@ -81,8 +81,8 @@
     {% set query %}
     create temp table {{table_name}}__base as
         select
-            {{ adapter.dispatch('synth_table_rownum')() }} as __row_number
-        from {{ adapter.dispatch('synth_table_generator')(rows) }}
+            {{ adapter.dispatch('synth_table_rownum', 'dbt_synth_data')() }} as __row_number
+        from {{ adapter.dispatch('synth_table_generator', 'dbt_synth_data')(rows) }}
     ;
     {% endset %}
     {% do run_query(query) %}

--- a/macros/util.sql
+++ b/macros/util.sql
@@ -14,7 +14,7 @@
 #}
 {% macro synth_get_randseed() %}
     {%- if not target.get("rand_seed") -%}
-    {%- do synth_set_randseed(var('synth_randseed')) -%}
+    {%- do dbt_synth_data.synth_set_randseed(var('synth_randseed')) -%}
     {%- set next_rand_seed = var('synth_randseed') -%}
     {%- else -%}
     {%- set next_rand_seed = target.get("rand_seed")|int + 1 -%}


### PR DESCRIPTION
Before this PR, I was getting compiler errors from dbt_synth_data like:
```
Compilation Error in model _my_model_fixture (models/.../fixtures/_my_model_fixture.sql)
  In dispatch: No macro named 'synth_distribution_continuous_uniform' found within namespace: 'None'
      Searched for: 'snowflake__synth_distribution_continuous_uniform', 'default__synth_distribution_continuous_uniform'
  
  > in macro synth_distribution_continuous_uniform (macros/distributions/continuous/uniform.sql)
  > called by macro synth_distribution_discrete_probabilities (macros/distributions/discrete/probabilities.sql)
  > called by macro synth_distribution_discrete (macros/distributions/util.sql)
  > called by macro synth_distribution (macros/distributions/util.sql)
  > called by model _my_model_fixture (models/.../fixtures/_my_model_fixture.sql)
```
I'm compiling against Snowflake, but I believe this affects all adapters.

This regression may have been caused by DBT's choice to move adapters out of dbt-core.